### PR TITLE
fix: 组件详情页顶部状态条颜色问题

### DIFF
--- a/lib/components/widget_comp.dart
+++ b/lib/components/widget_comp.dart
@@ -106,6 +106,7 @@ class IndexState extends State<Index> {
         actions: this.getActions(
           context,
         ),
+        brightness: Brightness.light,
         leading: IconButton(
           icon: Icon(Icons.arrow_back),
           color: Color(AppTheme.blackColor),


### PR DESCRIPTION
如题，组件详情页在iOS上是白色的导航栏，所以白色的状态栏就完全看不到了任何字了